### PR TITLE
Split build flags, honour external values

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -3,17 +3,17 @@ bindir = $(prefix)/bin
 libdir = $(prefix)/smlrc/lib
 incdir = $(prefix)/smlrc/include
 
-CFLAGS = -pipe -Wall -O2
-CFLAGS += -DPATH_PREFIX='"$(prefix)"'
+CFLAGS ?= -pipe -Wall -O2
+CPPFLAGS += -DPATH_PREFIX='"$(prefix)"'
 
-CC = gcc
+CC ?= gcc
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	CFLAGS += -DHOST_MACOS
+	CPPFLAGS += -DHOST_MACOS
 else
 # If not MacOS, assume Linux.
-	CFLAGS += -DHOST_LINUX
+	CPPFLAGS += -DHOST_LINUX
 endif
 
 bins = smlrc smlrl smlrcc smlrpp n2f
@@ -47,7 +47,7 @@ $(stub):
 	./smlrcc -small $(srcdir)/srclib/dpstub.asm -o $@
 
 smlrpp:
-	$(CC) $(CFLAGS) -o $@ -DSTAND_ALONE -DUCPP_CONFIG \
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ -DSTAND_ALONE -DUCPP_CONFIG \
 	$(srcdir)/ucpp/arith.c \
 	$(srcdir)/ucpp/assert.c \
 	$(srcdir)/ucpp/cpp.c \


### PR DESCRIPTION
CFLAGS and CC (among others) are commonly set by distribution build infrastructure. It's helpful if build systems apply those settings when appropriate; to do this in SmallerC, this changes CFLAGS and CC to only be set if they don't have an existing value.

C definitions are moved to CPPFLAGS, and appended to any existing values.

The smrlpp build is changed to apply CPPFLAGS and LDFLAGS as well as CFLAGS. (This is the default in Make, so it already applies to the other tools which rely on built-in rules.)